### PR TITLE
修复点击领取鱼丸按钮出现提示导致领取鱼丸列表向上偏移

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ https://userstyles.org/styles/132037/douyu-cleaner
 Follow me on github:
 https://github.com/AozakiOrenji/douyu-cleaner-plus
 
+[2017/11/13]
+[#]修复点击领取鱼丸按钮出现提示导致领取鱼丸列表向上偏移
+
 [2017/8/29]
 [#]将背包按钮加入回来（因为签到不怎么送鱼丸只送礼物了）
 

--- a/main.css
+++ b/main.css
@@ -43,7 +43,7 @@
     .enter-level1{
         display:none;
     }
-
+    
     /* 一直显示礼物剩余时间 */
     .yw-warmTip{
         display:block !important;
@@ -82,9 +82,16 @@
         left:200px !important;
         top:-25px !important;
         background: none !important;
-    }
-    .yw-collect-box{
         display:block !important;
+    }
+    /* 修复点击领取鱼丸按钮出现提示导致领取鱼丸列表向上偏移 */
+    .c-txt {
+			display: none !important;
+			height: 0px !important;
+    }
+	.get-yw .yw-collect-box.ywrmd {
+			padding: 28px 10px 17px 8px !important;
+			min-height: 35px !important;
     }
 
     /* 如要开启欢迎进入消息请为下面的规则添加注释 */


### PR DESCRIPTION
在等待鱼丸可以领取时间，点击礼物区最左侧礼物图标会出现 

> 别着急，奖励正在准备中，鱼丸、经验、道具等你来

导致领取鱼丸列表向上偏移。

此次提交修复此bug
